### PR TITLE
Keep annotations' text box always inside displayed area

### DIFF
--- a/src/drawing/drawLinkedTextBox.js
+++ b/src/drawing/drawLinkedTextBox.js
@@ -1,6 +1,8 @@
 import external from '../externalModules.js';
 import drawTextBox from './drawTextBox.js';
 import drawLink from './drawLink.js';
+import { state } from './../store/index.js';
+import { clipBoxToDisplayedArea } from '../util/clip.js';
 
 /**
  * Draw a link between an annotation to a textBox.
@@ -32,87 +34,26 @@ export default function(
   xOffset,
   yCenter
 ) {
-  const cornerstone = external.cornerstone;
+  const { pixelToCanvas } = external.cornerstone;
 
   // Convert the textbox Image coordinates into Canvas coordinates
-  const textCoords = cornerstone.pixelToCanvas(element, textBox);
+  const textCoords = pixelToCanvas(element, textBox);
 
   if (xOffset) {
     textCoords.x += xOffset;
   }
-
-  const getBoxPixelLimits = (element, box) => {
-    const toPixel = point => cornerstone.canvasToPixel(element, point);
-    const { top, left, width, height } = box;
-    const topLeft = toPixel({ x: left, y: top });
-    const topRight = toPixel({ x: left + width, y: top });
-    const bottomLeft = toPixel({ x: left, y: top + height });
-    const bottomRight = toPixel({ x: left + width, y: top + height });
-    const points = [topLeft, topRight, bottomLeft, bottomRight];
-    const xArray = points.map(p => p.x);
-    const yArray = points.map(p => p.y);
-
-    return {
-      minX: Math.min(...xArray),
-      minY: Math.min(...yArray),
-      maxX: Math.max(...xArray),
-      maxY: Math.max(...yArray),
-    };
-  };
-
-  const clipBoxOnAxis = (point, axis, min, max, upper, lower) => {
-    // Reposition bounding box in the given axis of the displayed area
-    if (lower - upper < max - min) {
-      // Box bigger than displayed area
-      point[axis] += upper - min; // Stick to the upper boundary
-      point[axis] += (lower - upper) / 2; // Centralize in displayed area
-      point[axis] -= (max - min) / 2; // Subtract 1/2 box's height
-    } else if (min < upper) {
-      // Leaked displayed area's upper boundary
-      point[axis] += upper - min; // Stick to the upper boundary
-    } else if (max > lower) {
-      // Leaked displayed area's lower boundary
-      point[axis] -= max - lower; // Stick to the lower boundary
-    }
-  };
 
   const options = {
     centering: {
       x: false,
       y: yCenter,
     },
-    translator(boundingBox) {
-      const { pixelToCanvas, canvasToPixel, getViewport } = cornerstone;
-      const pixelPosition = canvasToPixel(element, {
-        x: boundingBox.left,
-        y: boundingBox.top,
-      });
-      const { minX, minY, maxX, maxY } = getBoxPixelLimits(
-        element,
-        boundingBox
-      );
-
-      // Get the displayed area's top, left, bottom and right boundaries
-      const { tlhc, brhc } = getViewport(element).displayedArea;
-      const top = tlhc.y - 1;
-      const left = tlhc.x - 1;
-      const bottom = brhc.y;
-      const right = brhc.x;
-
-      // Clip the bounding box on vertical axis
-      clipBoxOnAxis(pixelPosition, 'y', minY, maxY, top, bottom);
-
-      // Clip the bounding box on horizontal axis
-      clipBoxOnAxis(pixelPosition, 'x', minX, maxX, left, right);
-
-      // Transform the bounding box coordinate system back to canvas
-      const newCanvasPosition = pixelToCanvas(element, pixelPosition);
-
-      // Update the bounding box with the new coordinates
-      boundingBox.top = newCanvasPosition.y;
-      boundingBox.left = newCanvasPosition.x;
-    },
   };
+
+  // Clip the bounding box to the displayed area of the image
+  if (state.preventTextBoxOutsideDisplayedArea) {
+    options.translator = box => clipBoxToDisplayedArea(element, box);
+  }
 
   // Draw the text box
   textBox.boundingBox = drawTextBox(
@@ -126,7 +67,7 @@ export default function(
   if (textBox.hasMoved) {
     // Identify the possible anchor points for the tool -> text line
     const linkAnchorPoints = textBoxAnchorPoints(handles).map(h =>
-      cornerstone.pixelToCanvas(element, h)
+      pixelToCanvas(element, h)
     );
 
     // Draw dashed link line between tool and text

--- a/src/drawing/drawLinkedTextBox.js
+++ b/src/drawing/drawLinkedTextBox.js
@@ -60,6 +60,22 @@ export default function(
     };
   };
 
+  const clipBoxOnAxis = (point, axis, min, max, upper, lower) => {
+    // Reposition bounding box in the given axis of the displayed area
+    if (lower - upper < max - min) {
+      // Box bigger than displayed area
+      point[axis] += upper - min; // Stick to the upper boundary
+      point[axis] += (lower - upper) / 2; // Centralize in displayed area
+      point[axis] -= (max - min) / 2; // Subtract 1/2 box's height
+    } else if (min < upper) {
+      // Leaked displayed area's upper boundary
+      point[axis] += upper - min; // Stick to the upper boundary
+    } else if (max > lower) {
+      // Leaked displayed area's lower boundary
+      point[axis] -= max - lower; // Stick to the lower boundary
+    }
+  };
+
   const options = {
     centering: {
       x: false,
@@ -83,33 +99,11 @@ export default function(
       const bottom = brhc.y;
       const right = brhc.x;
 
-      // Reposition bounding box in the vertical axis of the displayed area
-      if (bottom - top < maxY - minY) {
-        // Box bigger than displayed area
-        pixelPosition.y += top - minY; // Stick to the top boundary
-        pixelPosition.y += (bottom - top) / 2; // Centralize in displayed area
-        pixelPosition.y -= (maxY - minY) / 2; // Subtract 1/2 box's height
-      } else if (minY < top) {
-        // Leaked displayed area's top boundary
-        pixelPosition.y += top - minY; // Stick to the top boundary
-      } else if (maxY > bottom) {
-        // Leaked displayed area's bottom boundary
-        pixelPosition.y -= maxY - bottom; // Stick to the bottom boundary
-      }
+      // Clip the bounding box on vertical axis
+      clipBoxOnAxis(pixelPosition, 'y', minY, maxY, top, bottom);
 
-      // Reposition bounding box in the horiozontal axis of the displayed area
-      if (right - left < maxX - minX) {
-        // Box bigger than displayed area
-        pixelPosition.x += left - minX; // Stick to the left boundary
-        pixelPosition.x += (right - left) / 2; // Centralize in displayed area
-        pixelPosition.x -= (maxX - minX) / 2; // Subtract 1/2 box's width
-      } else if (minX < left) {
-        // Leaked displayed area's left boundary
-        pixelPosition.x += left - minX; // Stick to the left boundary
-      } else if (maxX > right) {
-        // Leaked displayed area's right boundary
-        pixelPosition.x -= maxX - right; // Stick to the right boundary
-      }
+      // Clip the bounding box on horizontal axis
+      clipBoxOnAxis(pixelPosition, 'x', minX, maxX, left, right);
 
       // Transform the bounding box coordinate system back to canvas
       const newCanvasPosition = pixelToCanvas(element, pixelPosition);

--- a/src/drawing/drawLinkedTextBox.js
+++ b/src/drawing/drawLinkedTextBox.js
@@ -66,10 +66,15 @@ export default function(
       y: yCenter,
     },
     translator(boundingBox) {
+      const pixelTopLeft = cornerstone.canvasToPixel(element, {
+        x: boundingBox.left,
+        y: boundingBox.top,
+      });
       const { minX, minY, maxX, maxY } = getBoxPixelLimits(
         element,
         boundingBox
       );
+
       const viewport = cornerstone.getViewport(element);
       const { tlhc, brhc } = viewport.displayedArea;
       const top = tlhc.y - 1;
@@ -81,29 +86,22 @@ export default function(
       const leakBottom = maxY > bottom;
       const leakRight = maxX > right;
 
-      if (leakTop || leakLeft || leakBottom || leakRight) {
-        console.warn('>>>>LEAKED');
+      if (leakTop) {
+        pixelTopLeft.y += top - minY;
+      } else if (leakBottom) {
+        pixelTopLeft.y -= maxY - bottom;
       }
 
-      // if (leakBottom) {
-      //   if (maxY - minY < height) {
-      //     boundingBox.top = minY + (maxY - minY) / 2 - height / 2;
-      //   } else {
-      //     boundingBox.top = maxY - height;
-      //   }
-      // } else if (leakTop) {
-      //   boundingBox.top = minY;
-      // }
+      if (leakLeft) {
+        pixelTopLeft.x += left - minX;
+      } else if (leakRight) {
+        pixelTopLeft.x -= maxX - right;
+      }
 
-      // if (leakRight) {
-      //   if (maxX - minX < width) {
-      //     boundingBox.left = minX + (maxX - minX) / 2 - width / 2;
-      //   } else {
-      //     boundingBox.left = maxX - width;
-      //   }
-      // } else if (leakLeft) {
-      //   boundingBox.left = minX;
-      // }
+      const canvasTopLeft = cornerstone.pixelToCanvas(element, pixelTopLeft);
+
+      boundingBox.top = canvasTopLeft.y;
+      boundingBox.left = canvasTopLeft.x;
     },
   };
 

--- a/src/drawing/drawLinkedTextBox.js
+++ b/src/drawing/drawLinkedTextBox.js
@@ -46,6 +46,43 @@ export default function(
       x: false,
       y: yCenter,
     },
+    translator(boundingBox) {
+      const { pixelToCanvas } = cornerstone;
+      const { width, height, left, top } = boundingBox;
+      const viewport = cornerstone.getViewport(element);
+      const { tlhc, brhc } = viewport.displayedArea;
+      const daTopLeft = { x: tlhc.x - 1, y: tlhc.y - 1 };
+      const { x: daLeft, y: daTop } = pixelToCanvas(element, daTopLeft);
+      const { x: daRight, y: daBottom } = pixelToCanvas(element, brhc);
+      const maxX = Math.max(daLeft, daRight);
+      const maxY = Math.max(daTop, daBottom);
+      const minX = Math.min(daLeft, daRight);
+      const minY = Math.min(daTop, daBottom);
+      const leakTop = top < minY;
+      const leakLeft = left < minX;
+      const leakBottom = top + height > maxY;
+      const leakRight = left + width > maxX;
+
+      if (leakBottom) {
+        if (maxY - minY < height) {
+          boundingBox.top = minY + (maxY - minY) / 2 - height / 2;
+        } else {
+          boundingBox.top = maxY - height;
+        }
+      } else if (leakTop) {
+        boundingBox.top = minY;
+      }
+
+      if (leakRight) {
+        if (maxX - minX < width) {
+          boundingBox.left = minX + (maxX - minX) / 2 - width / 2;
+        } else {
+          boundingBox.left = maxX - width;
+        }
+      } else if (leakLeft) {
+        boundingBox.left = minX;
+      }
+    },
   };
 
   // Draw the text box

--- a/src/drawing/drawLinkedTextBox.js
+++ b/src/drawing/drawLinkedTextBox.js
@@ -66,7 +66,8 @@ export default function(
       y: yCenter,
     },
     translator(boundingBox) {
-      const pixelTopLeft = cornerstone.canvasToPixel(element, {
+      const { pixelToCanvas, canvasToPixel, getViewport } = cornerstone;
+      const pixelTopLeft = canvasToPixel(element, {
         x: boundingBox.left,
         y: boundingBox.top,
       });
@@ -75,7 +76,7 @@ export default function(
         boundingBox
       );
 
-      const viewport = cornerstone.getViewport(element);
+      const viewport = getViewport(element);
       const { tlhc, brhc } = viewport.displayedArea;
       const top = tlhc.y - 1;
       const left = tlhc.x - 1;
@@ -86,13 +87,21 @@ export default function(
       const leakBottom = maxY > bottom;
       const leakRight = maxX > right;
 
-      if (leakTop) {
-        pixelTopLeft.y += top - minY;
+      if (bottom - top < maxY - minY) {
+        pixelTopLeft.y += top - minY; // Stick to the top boundary
+        pixelTopLeft.y += (bottom - top) / 2; // Move to the center of displayed area
+        pixelTopLeft.y -= (maxY - minY) / 2; // Translate half of the box's height
+      } else if (leakTop) {
+        pixelTopLeft.y += top - minY; // Stick to the top boundary
       } else if (leakBottom) {
         pixelTopLeft.y -= maxY - bottom;
       }
 
-      if (leakLeft) {
+      if (right - left < maxX - minX) {
+        pixelTopLeft.x -= minX - left;
+        pixelTopLeft.x += (right - left) / 2;
+        pixelTopLeft.x -= (maxX - minX) / 2;
+      } else if (leakLeft) {
         pixelTopLeft.x += left - minX;
       } else if (leakRight) {
         pixelTopLeft.x -= maxX - right;

--- a/src/lib.js
+++ b/src/lib.js
@@ -36,7 +36,7 @@ import {
   fillBox,
   fillTextLines,
 } from './drawing/index.js';
-import { clip, clipToBox } from './util/clip.js';
+import { clip, clipToBox, clipBoxToDisplayedArea } from './util/clip.js';
 import debounce from './util/debounce';
 import deepmerge from './util/deepmerge';
 import getDefault from './util/getDefault';
@@ -158,6 +158,7 @@ export const lib = {
   'util/convertToVector3': convertToVector3,
   'util/clip': clip,
   'util/clipToBox': clipToBox,
+  'util/clipBoxToDisplayedArea': clipBoxToDisplayedArea,
   'util/debounce': debounce,
   'util/deepmerge': deepmerge,
   'util/getDefault': getDefault,

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -185,9 +185,28 @@ function _dragHandler(
 
   if (options.preventHandleOutsideDisplayedArea) {
     const { tlhc, brhc } = viewport.displayedArea;
+    let limitX = brhc.x;
+    let limitY = brhc.y;
 
-    handle.x = clip(handle.x, tlhc.x - 1, brhc.x);
-    handle.y = clip(handle.y, tlhc.y - 1, brhc.y);
+    if (handle === annotation.handles.textBox && handle.boundingBox) {
+      const { top, left, width, height } = handle.boundingBox;
+      const tl = external.cornerstone.canvasToPixel(element, {
+        x: left,
+        y: top,
+      });
+      const br = external.cornerstone.canvasToPixel(element, {
+        x: left + width,
+        y: top + height,
+      });
+      const pixelWidth = Math.max(tl.x, br.x) - Math.min(tl.x, br.x);
+      const pixelHeight = Math.max(tl.y, br.y) - Math.min(tl.y, br.y);
+
+      limitX -= pixelWidth;
+      limitY -= pixelHeight;
+    }
+
+    handle.x = clip(handle.x, tlhc.x - 1, limitX);
+    handle.y = clip(handle.y, tlhc.y - 1, limitY);
   } else if (options.preventHandleOutsideImage) {
     clipToBox(handle, image);
   }

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -185,28 +185,9 @@ function _dragHandler(
 
   if (options.preventHandleOutsideDisplayedArea) {
     const { tlhc, brhc } = viewport.displayedArea;
-    let limitX = brhc.x;
-    let limitY = brhc.y;
 
-    if (handle === annotation.handles.textBox && handle.boundingBox) {
-      const { top, left, width, height } = handle.boundingBox;
-      const tl = external.cornerstone.canvasToPixel(element, {
-        x: left,
-        y: top,
-      });
-      const br = external.cornerstone.canvasToPixel(element, {
-        x: left + width,
-        y: top + height,
-      });
-      const pixelWidth = Math.max(tl.x, br.x) - Math.min(tl.x, br.x);
-      const pixelHeight = Math.max(tl.y, br.y) - Math.min(tl.y, br.y);
-
-      limitX -= pixelWidth;
-      limitY -= pixelHeight;
-    }
-
-    handle.x = clip(handle.x, tlhc.x - 1, limitX);
-    handle.y = clip(handle.y, tlhc.y - 1, limitY);
+    handle.x = clip(handle.x, tlhc.x - 1, brhc.x);
+    handle.y = clip(handle.y, tlhc.y - 1, brhc.y);
   } else if (options.preventHandleOutsideImage) {
     clipToBox(handle, image);
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -26,6 +26,7 @@ export const state = {
   deleteIfHandleOutsideImage: true,
   preventHandleOutsideDisplayedArea: false,
   preventHandleOutsideImage: false,
+  preventTextBoxOutsideDisplayedArea: false,
   // Average pixel width of index finger is 45-57 pixels
   // https://www.smashingmagazine.com/2012/02/finger-friendly-design-ideal-mobile-touchscreen-target-sizes/
   handleTouchOffset: { x: 0, y: -57 },

--- a/src/util/clip.js
+++ b/src/util/clip.js
@@ -24,15 +24,19 @@ export function clip(val, low, high) {
  * @returns {void}
  */
 export function clipToBox(point, box) {
-  // Clip an {x, y} point to a box of size {width, height}
-  point.x = clip(point.x, box.left || 0, box.width);
-  point.y = clip(point.y, box.top || 0, box.height);
+  // Clip an {x, y} point to a box {top, left, width, height}
+  const left = box.left || 0;
+  const top = box.top || 0;
+
+  point.x = clip(point.x, left, left + box.width);
+  point.y = clip(point.y, top, top + box.height);
 }
 
 /**
  * Returns a new bounding box of rotated text box, relative to the pixel
  * coordinate system. It will get the coordinate of the 4 points of the rotated
- * text box and calculate the lower and upper boundaries for `x` and `y` axes.
+ * text box and calculate the AABB (axis-aligned bounding box - lower and upper
+ * boundaries for `x` and `y` axes).
  *
  * @param {HTMLElement} element The element to manipulate pixel positioning
  * @param {Object} box - `{ left, top, width, height }` in canvas coordinates

--- a/src/util/clip.js
+++ b/src/util/clip.js
@@ -1,3 +1,5 @@
+import external from '../externalModules.js';
+
 /**
  * Clips a value to an upper and lower bound.
  * @export @public @method
@@ -23,8 +25,76 @@ export function clip(val, low, high) {
  */
 export function clipToBox(point, box) {
   // Clip an {x, y} point to a box of size {width, height}
-  point.x = clip(point.x, 0, box.width);
-  point.y = clip(point.y, 0, box.height);
+  point.x = clip(point.x, box.left || 0, box.width);
+  point.y = clip(point.y, box.top || 0, box.height);
+}
+
+const getBoxPixelLimits = (element, box) => {
+  const toPixel = point => external.cornerstone.canvasToPixel(element, point);
+  const { top, left, width, height } = box;
+  const topLeft = toPixel({ x: left, y: top });
+  const topRight = toPixel({ x: left + width, y: top });
+  const bottomLeft = toPixel({ x: left, y: top + height });
+  const bottomRight = toPixel({ x: left + width, y: top + height });
+  const points = [topLeft, topRight, bottomLeft, bottomRight];
+  const xArray = points.map(p => p.x);
+  const yArray = points.map(p => p.y);
+
+  return {
+    minX: Math.min(...xArray),
+    minY: Math.min(...yArray),
+    maxX: Math.max(...xArray),
+    maxY: Math.max(...yArray),
+  };
+};
+
+const clipBoxOnAxis = (point, axis, min, max, upper, lower) => {
+  // Reposition bounding box in the given axis of the displayed area
+  if (lower - upper < max - min) {
+    // Box bigger than displayed area
+    point[axis] += upper - min; // Stick to the upper boundary
+    point[axis] += (lower - upper) / 2; // Centralize in displayed area
+    point[axis] -= (max - min) / 2; // Subtract 1/2 box's height
+  } else if (min < upper) {
+    // Leaked displayed area's upper boundary
+    point[axis] += upper - min; // Stick to the upper boundary
+  } else if (max > lower) {
+    // Leaked displayed area's lower boundary
+    point[axis] -= max - lower; // Stick to the lower boundary
+  }
+};
+
+export function clipBoxToDisplayedArea(element, box) {
+  const { pixelToCanvas, canvasToPixel, getViewport } = external.cornerstone;
+
+  // Transform the position of given box from canvas to pixel coordinates
+  const pixelPosition = canvasToPixel(element, {
+    x: box.left,
+    y: box.top,
+  });
+
+  // Get the rotated corners' position for the box in pixel coordinate system
+  const { minX, minY, maxX, maxY } = getBoxPixelLimits(element, box);
+
+  // Get the displayed area's top, left, bottom and right boundaries
+  const { tlhc, brhc } = getViewport(element).displayedArea;
+  const top = tlhc.y - 1;
+  const left = tlhc.x - 1;
+  const bottom = brhc.y;
+  const right = brhc.x;
+
+  // Clip the box on vertical axis
+  clipBoxOnAxis(pixelPosition, 'y', minY, maxY, top, bottom);
+
+  // Clip the box on horizontal axis
+  clipBoxOnAxis(pixelPosition, 'x', minX, maxX, left, right);
+
+  // Transform the box coordinate system back to canvas
+  const newCanvasPosition = pixelToCanvas(element, pixelPosition);
+
+  // Update the box with the new coordinates
+  box.top = newCanvasPosition.y;
+  box.left = newCanvasPosition.x;
 }
 
 export default clip;


### PR DESCRIPTION
### Changes included

- Added `preventTextBoxOutsideDisplayedArea` configuration flag to control text boxes leaking the displayed area of the image.
 - Created a `clipBoxToDisplayedArea` clipping method which will clip a box shape to the displayed area's boundaries, even when viewport is rotated/flipped.
 - Started clipping the text box for all annotation tools to the displayed area when the `preventTextBoxOutsideDisplayedArea` state flag is set to `true`.